### PR TITLE
Adding shell style, expanding metadata and adding author attribution in LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015 <Your name here>
+Copyright (c) 2015-2016 Murriouz <Murriouz@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/index.less
+++ b/index.less
@@ -13,3 +13,4 @@
 @import 'languages/json';
 @import 'languages/ruby';
 @import 'languages/python';
+@import 'languages/shell';

--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "dark-bint-syntax",
   "theme": "syntax",
   "version": "0.8.4",
-  "description": "A short description of your syntax theme",
+  "author": "Murriouz <Murriouz@gmail.com>",
+  "readme": "./README.md",
+  "description": "A dark and colourful syntax theme.",
   "keywords": [
     "syntax",
     "theme"
   ],
-  "repository": "https://github.com/MiincGu/dark-bint-syntax",
+  "repository": "https://github.com/Murriouz/dark-bint-syntax",
   "license": "MIT",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"

--- a/styles/languages/shell.less
+++ b/styles/languages/shell.less
@@ -1,15 +1,13 @@
 .source.shell {
-  .support.function {
-    .coreutils {
-      color: rgb(150,255,150);
-    }
+  .support.function.coreutils {
+    color: rgb(150,255,150);
+  }
 
-    .extras {
+  .support.function.extras {
     color: rgb(255,150,200);
-    }
+  }
 
-    .packages {
+  .support.function.packages {
     color: rgb(255,220,120);
-    }
   }
 }

--- a/styles/languages/shell.less
+++ b/styles/languages/shell.less
@@ -1,0 +1,15 @@
+.source.shell {
+  .support.function {
+    .coreutils {
+      color: rgb(150,255,150);
+    }
+
+    .extras {
+    color: rgb(255,150,200);
+    }
+
+    .packages {
+    color: rgb(255,220,120);
+    }
+  }
+}


### PR DESCRIPTION
Hi,

In this pull I am merely adding additional shell script support to this theme, which should work hand-in-hand with another [pull request](https://github.com/atom/language-shellscript/pull/50) I just started for the core `language-shellscript` package. 

Thanks for your time,
Brenton
