### PR TITLE
Expanding shell styles

### DIFF
--- a/styles/languages/shell.less
+++ b/styles/languages/shell.less
@@ -27,6 +27,10 @@
     color: rgb(255,220,120);
   }
 
+  .support.function.vcs {
+    color: rgb(255,255,0);
+  }
+
   .variable.definition.name {
     color: rgb(120,255,90);
   }
@@ -35,4 +39,3 @@
     color: inherit;
   }
 }
-

--- a/styles/languages/shell.less
+++ b/styles/languages/shell.less
@@ -1,13 +1,38 @@
 .source.shell {
+  .entity.name.function {
+    color: rgb(140,72,184);
+  }
+
+  .keyword.operator.pipe {
+    color: rgb(200,120,20);
+  }
+
+  .punctuation.definition.logical-expression {
+    color: rgb(255,90,90);
+  }
+
+  .support.function.builtin {
+    color: rgb(0,160,0);
+  }
+
   .support.function.coreutils {
-    color: rgb(150,255,150);
+    color: rgb(255,0,100);
   }
 
   .support.function.extras {
-    color: rgb(255,150,200);
+    color: rgb(60,105,180);
   }
 
   .support.function.packages {
     color: rgb(255,220,120);
   }
+
+  .variable.definition.name {
+    color: rgb(120,255,90);
+  }
+
+  .variable.definition.equal {
+    color: inherit;
+  }
 }
+


### PR DESCRIPTION
Hi,

This is just one last pull to make this theme give shell script wonderful syntax-highlighting. Sorry, I should have completed it before I made my last pull. Here is a screenshot showing the syntax-highlighting this pull provides, if combined with [fusion809/language-shellscript](https://github.com/fusion809/language-shellscript). 

![My atom-editor-beta PKGBUILD being highlighted by dark-bint-syntax with my custom language-shellscript](http://imgur.com/Z1931NH.png)

Thanks for your time,
Brenton
